### PR TITLE
Require TLS when validating log sink configs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "vendor/k8s.io/code-generator"]
-	path = vendor/k8s.io/code-generator
-	url = https://github.com/kubernetes/code-generator
-	branch = release-1.14

--- a/pkg/apis/sink/v1alpha1/types.go
+++ b/pkg/apis/sink/v1alpha1/types.go
@@ -35,15 +35,15 @@ type LogSink struct {
 type SinkSpec struct {
 	Type string `json:"type"`
 
-	SyslogSpec  `json:",inline"`
-	WebhookSpec `json:",inline"`
+	SyslogSpec         `json:",inline"`
+	WebhookSpec        `json:",inline"`
+	InsecureSkipVerify bool `json:"insecure_skip_verify"`
 }
 
 type SyslogSpec struct {
-	Host               string `json:"host"`
-	Port               int    `json:"port"`
-	EnableTLS          bool   `json:"enable_tls"`
-	InsecureSkipVerify bool   `json:"insecure_skip_verify"`
+	Host      string `json:"host"`
+	Port      int    `json:"port"`
+	EnableTLS bool   `json:"enable_tls"`
 }
 
 type WebhookSpec struct {

--- a/pkg/sink/cluster_controller_test.go
+++ b/pkg/sink/cluster_controller_test.go
@@ -57,7 +57,7 @@ func TestClusterSinkModification(t *testing.T) {
 			"Add a single TLS sink with insecure skip verify set",
 			[]string{"add"},
 			[]v1alpha1.SinkSpec{
-				{Type: "syslog", SyslogSpec: v1alpha1.SyslogSpec{Host: "example.com", Port: 12345, EnableTLS: true, InsecureSkipVerify: true}},
+				{Type: "syslog", SyslogSpec: v1alpha1.SyslogSpec{Host: "example.com", Port: 12345, EnableTLS: true}, InsecureSkipVerify: true},
 			},
 			[]string{
 				"\n[OUTPUT]\n    Name syslog\n    Match *\n    StatsAddr 127.0.0.1:5000\n    Sinks []\n    ClusterSinks [{\"addr\":\"example.com:12345\",\"tls\":{\"insecure_skip_verify\":true},\"name\":\"sink-example.com\"}]\n",

--- a/pkg/sink/config.go
+++ b/pkg/sink/config.go
@@ -41,7 +41,7 @@ const httpOutputConfig = `
     Host %s
     Port %s
     URI %s
-    %s
+%s
 `
 
 type Config struct {
@@ -99,7 +99,7 @@ func (sc *Config) webhookConfig() string {
 			continue
 		}
 
-		config += buildHTTPConfig(s.Namespace, s.Spec.URL, false)
+		config += buildHTTPConfig(s.Namespace, s.Spec, false)
 	}
 
 	for _, s := range sc.clusterSinks {
@@ -107,7 +107,7 @@ func (sc *Config) webhookConfig() string {
 			continue
 		}
 
-		config += buildHTTPConfig("", s.Spec.URL, true)
+		config += buildHTTPConfig("", s.Spec, true)
 	}
 
 	return config
@@ -198,8 +198,8 @@ type tls struct {
 	InsecureSkipVerify bool `json:"insecure_skip_verify,omitempty"`
 }
 
-func buildHTTPConfig(namespace, URL string, isCluster bool) string {
-	url, err := url.Parse(URL)
+func buildHTTPConfig(namespace string, spec v1alpha1.SinkSpec, isCluster bool) string {
+	url, err := url.Parse(spec.URL)
 	if err != nil {
 		return ""
 	}
@@ -219,7 +219,11 @@ func buildHTTPConfig(namespace, URL string, isCluster bool) string {
 
 	var extras string
 	if url.Scheme == "https" {
-		extras = "tls On"
+		extras = "    tls On\n"
+
+		if spec.InsecureSkipVerify {
+			extras += "    tls.verify Off\n"
+		}
 	}
 
 	match := fmt.Sprintf("*_%s_*", namespace)

--- a/pkg/sink/config_test.go
+++ b/pkg/sink/config_test.go
@@ -883,6 +883,65 @@ func TestWebhookSinks(t *testing.T) {
 				},
 			),
 		},
+		"namespaced with https and skip cert verify": {
+			logSinks: []*v1alpha1.LogSink{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-name",
+						Namespace: "some-namespace",
+					},
+					Spec: v1alpha1.SinkSpec{
+						Type: "webhook",
+						WebhookSpec: v1alpha1.WebhookSpec{
+							URL: "https://example.com/some/path",
+						},
+						InsecureSkipVerify: true,
+					},
+				},
+			},
+			expectedConfig: sinksToConfigAST(
+				t,
+				[]namespaceSink{},
+				[]clusterSink{},
+				flbconfig.Section{
+					Name: "OUTPUT",
+					KeyValues: []flbconfig.KeyValue{
+						{
+							Key:   "Name",
+							Value: "http",
+						},
+						{
+							Key:   "Match",
+							Value: "*_some-namespace_*",
+						},
+						{
+							Key:   "Format",
+							Value: "json",
+						},
+						{
+							Key:   "Host",
+							Value: "example.com",
+						},
+						{
+							Key:   "Port",
+							Value: "443",
+						},
+						{
+							Key:   "URI",
+							Value: "/some/path",
+						},
+						{
+							Key:   "tls",
+							Value: "On",
+						},
+						{
+							Key:   "tls.verify",
+							Value: "Off",
+						},
+					},
+				},
+			),
+		},
 		"namespace with http URL": {
 			logSinks: []*v1alpha1.LogSink{
 				{

--- a/pkg/sink/controller_test.go
+++ b/pkg/sink/controller_test.go
@@ -64,7 +64,7 @@ func TestSinkModification(t *testing.T) {
 			"Add a single TLS sink with skip verify set",
 			[]string{"add"},
 			[]v1alpha1.SinkSpec{
-				{Type: "syslog", SyslogSpec: v1alpha1.SyslogSpec{Host: "example.com", Port: 12345, EnableTLS: true, InsecureSkipVerify: true}},
+				{Type: "syslog", SyslogSpec: v1alpha1.SyslogSpec{Host: "example.com", Port: 12345, EnableTLS: true}, InsecureSkipVerify: true},
 			},
 			[]string{
 				"\n[OUTPUT]\n    Name syslog\n    Match *\n    StatsAddr 127.0.0.1:5000\n    Sinks [{\"addr\":\"example.com:12345\",\"namespace\":\"test-ns\",\"tls\":{\"insecure_skip_verify\":true},\"name\":\"sink-example.com\"}]\n    ClusterSinks []\n",

--- a/pkg/sink/flbconfig/lex.go
+++ b/pkg/sink/flbconfig/lex.go
@@ -194,7 +194,7 @@ func LexKey(l *Lexer) StateFunc {
 		}
 
 		next := l.PeekNext()
-		if !unicode.IsLetter(next) && !unicode.IsNumber(next) {
+		if !unicode.IsLetter(next) && !unicode.IsNumber(next) && next != '.' {
 			switch next {
 			case RuneTab, RuneSpace:
 				l.Emit(TokenKey)

--- a/pkg/sink/flbconfig/lex_test.go
+++ b/pkg/sink/flbconfig/lex_test.go
@@ -132,6 +132,7 @@ keyA2 valA2
 [sectionB]
 keyB1 valB1
 keyB2 valB2
+keyB1.subkey valB1s
 
 `,
 			expectedTokens: []flbconfig.Token{
@@ -222,6 +223,18 @@ keyB2 valB2
 				{
 					Type:  flbconfig.TokenValue,
 					Value: "valB2",
+				},
+				{
+					Type:  flbconfig.TokenNewLine,
+					Value: "\n",
+				},
+				{
+					Type:  flbconfig.TokenKey,
+					Value: "keyB1.subkey",
+				},
+				{
+					Type:  flbconfig.TokenValue,
+					Value: "valB1s",
 				},
 				{
 					Type:  flbconfig.TokenNewLine,

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os/exec"
+	"strings"
 	"sync"
 	"time"
 
@@ -27,7 +28,9 @@ const (
 	ConfigLogChangeTypeError       = "Changing sink type invalid"
 	ConfigSyslogBadPortError       = "Port for syslog invalid, should be between 1 and 65535"
 	ConfigSyslogBadHostError       = "Host for syslog invalid"
+	ConfigSyslogInsecureError      = "Insecure syslog sink not allowed"
 	ConfigWebhookBadURLError       = "URL for webhook invalid"
+	ConfigWebhookInsecureError     = "Insecure webhook not allowed, scheme must be https"
 	ConfigMetricNoTypeError        = "Must specify type for each inputs/outputs"
 	ConfigMetricNonStringTypeError = "Input/output type must be a string"
 	ConfigMetricNoInputError       = "MetricSinks require at least one input"
@@ -205,6 +208,9 @@ func validateLogSinkConfigRequest(rar *v1beta1.AdmissionReview) (*v1beta1.Admiss
 
 	switch cls.Spec.Type {
 	case "syslog":
+		if !cls.Spec.EnableTLS {
+			return toAdmissionErrorResponse(ConfigSyslogInsecureError), nil
+		}
 		if cls.Spec.Host == "" {
 			return toAdmissionErrorResponse(ConfigSyslogBadHostError), nil
 		}
@@ -214,6 +220,9 @@ func validateLogSinkConfigRequest(rar *v1beta1.AdmissionReview) (*v1beta1.Admiss
 	case "webhook":
 		if cls.Spec.URL == "" {
 			return toAdmissionErrorResponse(ConfigWebhookBadURLError), nil
+		}
+		if !strings.HasPrefix(cls.Spec.URL, "https://") {
+			return toAdmissionErrorResponse(ConfigWebhookInsecureError), nil
 		}
 	default:
 		return toAdmissionErrorResponse(ConfigLogNoTypeError), nil

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -177,7 +177,8 @@ func TestValidator(t *testing.T) {
 					`{
 						"type": "syslog",
 						"host": "example.com",
-						"port": 100
+						"port": 100,
+						"enable_tls": true
 					}`,
 				},
 				{
@@ -241,7 +242,8 @@ func TestValidator(t *testing.T) {
 					"no type",
 					`{
 						"host": "example.com",
-						"port": 0
+						"port": 0,
+						"enable_tls": true
 					}`,
 					"LogSink should have type",
 				},
@@ -250,7 +252,8 @@ func TestValidator(t *testing.T) {
 					`{
 						"type": "syslog",
 						"host": "example.com",
-						"port": 100000
+						"port": 100000,
+						"enable_tls": true
 					}`,
 					"Port for syslog invalid, should be between 1 and 65535",
 				},
@@ -259,7 +262,8 @@ func TestValidator(t *testing.T) {
 					`{
 						"type": "syslog",
 						"host": "example.com",
-						"port": 0
+						"port": 0,
+						"enable_tls": true
 					}`,
 					"Port for syslog invalid, should be between 1 and 65535",
 				},
@@ -267,7 +271,8 @@ func TestValidator(t *testing.T) {
 					"no port",
 					`{
 						"type": "syslog",
-						"host": "example.com"
+						"host": "example.com",
+						"enable_tls": true
 					}`,
 					"Port for syslog invalid, should be between 1 and 65535",
 				},
@@ -275,7 +280,8 @@ func TestValidator(t *testing.T) {
 					"no host",
 					`{
 						"type": "syslog",
-						"port": 0
+						"port": 1,
+						"enable_tls": true
 					}`,
 					"Host for syslog invalid",
 				},
@@ -294,6 +300,23 @@ func TestValidator(t *testing.T) {
 						"port": 5678
 					}`,
 					"URL for webhook invalid",
+				},
+				{
+					"insecure syslog",
+					`{
+						"type": "syslog",
+						"host": "example.com",
+						"port": 5678
+					}`,
+					"Insecure syslog sink not allowed",
+				},
+				{
+					"insecure webhook",
+					`{
+						"type": "webhook",
+						"url": "http://webhook.com"
+					}`,
+					"Insecure webhook not allowed, scheme must be https",
 				},
 			}
 			server := webhook.NewServer("127.0.0.1:0")

--- a/test/crd/invalid/cluster-syslog-host-type.yaml
+++ b/test/crd/invalid/cluster-syslog-host-type.yaml
@@ -20,3 +20,4 @@ spec:
   type: syslog
   host: 12345
   port: 12345
+  enable_tls: true

--- a/test/crd/invalid/pending-syslog-bad-hostname.yaml
+++ b/test/crd/invalid/pending-syslog-bad-hostname.yaml
@@ -20,3 +20,4 @@ spec:
   type: syslog
   host: example/com
   port: 12345
+  enable_tls: true

--- a/test/crd/invalid/pending-syslog-bad-ipv6-address.yaml
+++ b/test/crd/invalid/pending-syslog-bad-ipv6-address.yaml
@@ -20,3 +20,4 @@ spec:
   type: syslog
   host: "zz::"
   port: 12345
+  enable_tls: true

--- a/test/crd/invalid/sink-type.yaml
+++ b/test/crd/invalid/sink-type.yaml
@@ -20,3 +20,4 @@ spec:
   type: some-other-protocol
   host: example.com
   port: 12345
+  enable_tls: true

--- a/test/crd/invalid/syslog-high-port.yaml
+++ b/test/crd/invalid/syslog-high-port.yaml
@@ -20,3 +20,4 @@ spec:
   type: syslog
   host: example.com
   port: 70000
+  enable_tls: true

--- a/test/crd/invalid/syslog-host-type.yaml
+++ b/test/crd/invalid/syslog-host-type.yaml
@@ -20,3 +20,4 @@ spec:
   type: syslog
   host: 12345
   port: 12345
+  enable_tls: true

--- a/test/crd/invalid/syslog-low-port.yaml
+++ b/test/crd/invalid/syslog-low-port.yaml
@@ -20,3 +20,4 @@ spec:
   type: syslog
   host: example.com
   port: 0
+  enable_tls: true

--- a/test/crd/invalid/syslog-no-host.yaml
+++ b/test/crd/invalid/syslog-no-host.yaml
@@ -19,3 +19,4 @@ metadata:
 spec:
   type: syslog
   port: 12345
+  enable_tls: true

--- a/test/crd/invalid/syslog-no-port.yaml
+++ b/test/crd/invalid/syslog-no-port.yaml
@@ -19,3 +19,4 @@ metadata:
 spec:
   type: syslog
   host: example.com
+  enable_tls: true

--- a/test/crd/invalid/syslog-no-tls.yaml
+++ b/test/crd/invalid/syslog-no-tls.yaml
@@ -15,9 +15,8 @@
 apiVersion: observability.knative.dev/v1alpha1
 kind: LogSink
 metadata:
-  name: valid-syslog-tls
+  name: invalid-syslog-no-tls
 spec:
   type: syslog
   host: example.com
   port: 12345
-  enable_tls: true

--- a/test/crd/invalid/syslog-port-type.yaml
+++ b/test/crd/invalid/syslog-port-type.yaml
@@ -20,3 +20,4 @@ spec:
   type: syslog
   host: example.com
   port: foobar
+  enable_tls: true

--- a/test/crd/invalid/webhook-no-tls.yaml
+++ b/test/crd/invalid/webhook-no-tls.yaml
@@ -15,8 +15,7 @@
 apiVersion: observability.knative.dev/v1alpha1
 kind: LogSink
 metadata:
-  name: invalid-no-drain-type
+  name: invalid-webhook-no-tls
 spec:
-  host: example.com
-  port: 12345
-  enable_tls: true
+  type: webhook
+  url: http://example.com/test

--- a/test/crd/valid/cluster-syslog-hostname.yaml
+++ b/test/crd/valid/cluster-syslog-hostname.yaml
@@ -20,3 +20,4 @@ spec:
   type: syslog
   host: example.com
   port: 12343
+  enable_tls: true

--- a/test/crd/valid/syslog-high-port.yaml
+++ b/test/crd/valid/syslog-high-port.yaml
@@ -20,3 +20,4 @@ spec:
   type: syslog
   host: example.com
   port: 65535
+  enable_tls: true

--- a/test/crd/valid/syslog-hostname.yaml
+++ b/test/crd/valid/syslog-hostname.yaml
@@ -20,3 +20,4 @@ spec:
   type: syslog
   host: example.com
   port: 12345
+  enable_tls: true

--- a/test/crd/valid/syslog-ipv4-address.yaml
+++ b/test/crd/valid/syslog-ipv4-address.yaml
@@ -20,3 +20,4 @@ spec:
   type: syslog
   host: 127.0.0.1
   port: 12345
+  enable_tls: true

--- a/test/crd/valid/syslog-ipv6-address.yaml
+++ b/test/crd/valid/syslog-ipv6-address.yaml
@@ -20,3 +20,4 @@ spec:
   type: syslog
   host: "::"
   port: 12345
+  enable_tls: true

--- a/test/crd/valid/syslog-low-port.yaml
+++ b/test/crd/valid/syslog-low-port.yaml
@@ -20,3 +20,4 @@ spec:
   type: syslog
   host: example.com
   port: 1
+  enable_tls: true

--- a/test/e2e/clusterlogsink_test.go
+++ b/test/e2e/clusterlogsink_test.go
@@ -130,9 +130,11 @@ func createClusterLogSink(
 		Spec: v1alpha1.SinkSpec{
 			Type: "syslog",
 			SyslogSpec: v1alpha1.SyslogSpec{
-				Host: prefix + "syslog-receiver." + observabilityTestNamespace,
-				Port: 24903,
+				Host:      prefix + "syslog-receiver." + observabilityTestNamespace,
+				Port:      24903,
+				EnableTLS: true,
 			},
+			InsecureSkipVerify: true,
 		},
 	})
 	assertErr(t, "Error creating ClusterLogSink: %v", err)
@@ -158,8 +160,9 @@ func createClusterWebhookLogSink(
 		Spec: v1alpha1.SinkSpec{
 			Type: "webhook",
 			WebhookSpec: v1alpha1.WebhookSpec{
-				URL: "http://" + prefix + "syslog-receiver." + observabilityTestNamespace + ":7070/webhook",
+				URL: "https://" + prefix + "syslog-receiver." + observabilityTestNamespace + ":7070/webhook",
 			},
+			InsecureSkipVerify: true,
 		},
 	})
 	assertErr(t, "Error creating ClusterLogSink: %v", err)

--- a/test/e2e/logsink_test.go
+++ b/test/e2e/logsink_test.go
@@ -177,9 +177,11 @@ func createSyslogLogSink(
 		Spec: v1alpha1.SinkSpec{
 			Type: "syslog",
 			SyslogSpec: v1alpha1.SyslogSpec{
-				Host: prefix + syslogReceiverSuffix + "." + namespace,
-				Port: 24903,
+				Host:      prefix + syslogReceiverSuffix + "." + namespace,
+				Port:      24903,
+				EnableTLS: true,
 			},
+			InsecureSkipVerify: true,
 		},
 	})
 	assertErr(t, "Error creating syslog LogSink: %v", err)
@@ -205,8 +207,9 @@ func createWebhookLogSink(
 		Spec: v1alpha1.SinkSpec{
 			Type: "webhook",
 			WebhookSpec: v1alpha1.WebhookSpec{
-				URL: "http://" + prefix + syslogReceiverSuffix + "." + namespace + ":7070/webhook",
+				URL: "https://" + prefix + syslogReceiverSuffix + "." + namespace + ":7070/webhook",
 			},
+			InsecureSkipVerify: true,
 		},
 	})
 	assertErr(t, "Error creating webhook LogSink: %v", err)

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -435,7 +435,7 @@ func createSyslogReceiver(
 			ServiceAccountName: serviceAccountName,
 			Containers: []corev1.Container{{
 				Name:            syslogReceiverSuffix,
-				Image:           "oratos/crosstalk-receiver:v0.5",
+				Image:           "oratos/crosstalk-receiver:v0.6",
 				ImagePullPolicy: corev1.PullAlways,
 				Ports: []corev1.ContainerPort{
 					{


### PR DESCRIPTION
- vendor in code generation
- update all the kubernetes
- update tests for requiring tls

Signed-off-by: Ben Fuller <bfuller@pivotal.io>
Co-authored-by: Ben Fuller <bfuller@pivotal.io>